### PR TITLE
react-router-dom problem fixed

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "^4.3.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-router-dom": "^4.4.0",
+    "react-router-dom": "^5.0.0",
     "react-scripts": "2.1.8",
     "reactstrap": "^7.1.0"
   },


### PR DESCRIPTION
'In the end, we decided that the fix that would cause the least pain for everyone would be to npm unpublish version 4.4.0 and re-release it as 5.0.0.'

this is quoted from the developers of react-router-dom.